### PR TITLE
Fixed case issue for b.tLock

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -78,8 +78,8 @@ func (b *Broker) Detach(s *Subscriber) {
 
 // Broadcast broadcast the specified payload to all the topic(s) subscribers
 func (b *Broker) Broadcast(payload interface{}, topics ...string) {
-	b.tlock.RLock()
-	defer b.tlock.RUnlock()
+	b.tLock.RLock()
+	defer b.tLock.RUnlock()
 
 	for _, topic := range topics {
 		if b.Subscribers(topic) < 1 {


### PR DESCRIPTION
Fixed case issue due to the following:
../go/pkg/mod/github.com/alash3al/go-pubsub@v0.0.0-20200117151632-6314f8a71706/broker.go:81:3: b.tlock undefined (type *Broker has no field or method tlock, but does have tLock)
../go/pkg/mod/github.com/alash3al/go-pubsub@v0.0.0-20200117151632-6314f8a71706/broker.go:82:9: b.tlock undefined (type *Broker has no field or method tlock, but does have tLock)
